### PR TITLE
Extended verbs support

### DIFF
--- a/MiniShellFramework/ComTypes/QueryContextMenuOptions.cs
+++ b/MiniShellFramework/ComTypes/QueryContextMenuOptions.cs
@@ -56,6 +56,13 @@ namespace MiniShellFramework.ComTypes
         /// A drag-and-drop handler should ignore this flag.
         /// A namespace extension should not set any of the menu items as the default. (CMF_NODEFAULT)
         /// </summary>
-        NoDefault = 0x00000020
+        NoDefault = 0x00000020,
+
+        ///<summary>
+        ///The calling application wants extended verbs.
+        ///Normal verbs are displayed when the user right-clicks an object.
+        ///To display extended verbs, the user must right-click while pressing the Shift key. (CMF_EXTENDEDVERBS)
+        /// </summary>
+        ExtendedVerbs = 0x00000100
     }
 }

--- a/MiniShellFramework/ContextMenuBase.cs
+++ b/MiniShellFramework/ContextMenuBase.cs
@@ -47,7 +47,7 @@ namespace MiniShellFramework
             menuItems.Clear();
             currentCommandId = firstCommandId;
             startCommandId = firstCommandId;
-            QueryContextMenuCore(new Menu(menuHandle, position, lastCommandId, this), FilesNames);
+            QueryContextMenuCore(new Menu(menuHandle, position, lastCommandId, this), FilesNames, flags);
             return HResults.Create(Severity.Success, (ushort)(currentCommandId - firstCommandId));
         }
 
@@ -222,7 +222,8 @@ namespace MiniShellFramework
         /// </summary>
         /// <param name="menu">The menu.</param>
         /// <param name="filenames">The filenames.</param>
-        protected abstract void QueryContextMenuCore(Menu menu, IList<string> filenames);
+        /// <param name="flags">The flags</param>
+        protected abstract void QueryContextMenuCore(Menu menu, IList<string> filenames, QueryContextMenuOptions flags);
 
         /// <summary>
         /// Called when [init menu popup].

--- a/VvvSample/ContextMenu.cs
+++ b/VvvSample/ContextMenu.cs
@@ -41,7 +41,7 @@ namespace VvvSample
             ComUnregister(type, "VVV ContextMenu (MMSF Sample)", VvvRootKey.ProgId);
         }
 
-        protected override void QueryContextMenuCore(Menu menu, IList<string> filenames)
+        protected override void QueryContextMenuCore(Menu menu, IList<string> filenames, QueryContextMenuOptions flags)
         {
             if (filenames.Count != 1 || ContainsUnknownExtension(filenames))
                 return; // In this sample only extend the menu when only 1 .mvvv file is selected.


### PR DESCRIPTION
Add support to handle shift (Extended verbs) or more QueryContextMenuOptions on QueryContextMenuCore
problem the modification is not source compatible with old implementation because flags argument is added to QueryContextMenuCore